### PR TITLE
Use --quiet for the black formatter

### DIFF
--- a/lua/guard/tools/formatter.lua
+++ b/lua/guard/tools/formatter.lua
@@ -8,7 +8,7 @@ M.lsp = {
 
 M.black = {
   cmd = 'black',
-  args = { '-' },
+  args = { '--quiet', '-' },
   stdin = true,
 }
 


### PR DESCRIPTION
black will output some stderr (`All done! ✨ 🍰 ✨`) without it and that was causing guard to think there was an error.